### PR TITLE
 v2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codeinc/psr15-router-middleware",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A PSR-15 router middleware",
   "homepage": "https://github.com/CodeIncHQ/Psr15RouterMiddleware",
   "type": "library",

--- a/src/Exceptions/ControllerInstantiatingException.php
+++ b/src/Exceptions/ControllerInstantiatingException.php
@@ -16,33 +16,49 @@
 //
 // Author:   Joan Fabrégat <joan@codeinc.fr>
 // Date:     03/07/2018
-// Time:     13:03
+// Time:     14:31
 // Project:  Psr15RouterMiddleware
 //
 declare(strict_types=1);
-namespace CodeInc\Psr15RouterMiddleware;
-use Psr\Http\Message\ResponseInterface;
+namespace CodeInc\Psr15RouterMiddleware\Exceptions;
+use Throwable;
 
 
 /**
- * Interface ControllerInterface
+ * Class ControllerInstantiatingException
  *
- * @package CodeInc\Psr15RouterMiddleware
+ * @package CodeInc\Psr15RouterMiddleware\Exceptions
  * @author Joan Fabrégat <joan@codeinc.fr>
  */
-interface ControllerInterface
+class ControllerInstantiatingException extends RouterMiddlewareException
 {
     /**
-     * Executes the controller. This method must returns a PSR-7 response or throw an exception.
-     *
-     * @return ResponseInterface
+     * @var string
      */
-    public function getResponse():ResponseInterface;
+    private $controllerClass;
 
     /**
-     * Returns the controller's URI path.
+     * ControllerInstantiatingException constructor.
      *
+     * @param string $controllerClass
+     * @param int $code
+     * @param null|Throwable $previous
+     */
+    public function __construct(string $controllerClass, int $code = 0, ?Throwable $previous = null)
+    {
+        $this->controllerClass = $controllerClass;
+        parent::__construct(
+            sprintf("Error while instantiating the controller '%s'", $controllerClass),
+            $code,
+            $previous
+        );
+    }
+
+    /**
      * @return string
      */
-    public static function getUriPath():string;
+    public function getControllerClass():string
+    {
+        return $this->controllerClass;
+    }
 }

--- a/src/Exceptions/ControllerProcessingException.php
+++ b/src/Exceptions/ControllerProcessingException.php
@@ -21,6 +21,7 @@
 //
 declare(strict_types=1);
 namespace CodeInc\Psr15RouterMiddleware\Exceptions;
+use CodeInc\Psr15RouterMiddleware\ControllerInterface;
 use Throwable;
 
 
@@ -33,32 +34,32 @@ use Throwable;
 class ControllerProcessingException extends RouterMiddlewareException
 {
     /**
-     * @var string
+     * @var ControllerInterface
      */
-    private $controllerClass;
+    private $controller;
 
     /**
      * ControllerProcessingException constructor.
      *
-     * @param string $controllerClass
+     * @param ControllerInterface $controller
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct(string $controllerClass, int $code = 0, ?Throwable $previous = null)
+    public function __construct(ControllerInterface $controller, int $code = 0, ?Throwable $previous = null)
     {
-        $this->controllerClass = $controllerClass;
+        $this->controller = $controller;
         parent::__construct(
-            sprintf("Error while processing the controller '%s'", $controllerClass),
+            sprintf("Error while processing the controller '%s'", $controller),
             $code,
             $previous
         );
     }
 
     /**
-     * @return string
+     * @return ControllerInterface
      */
-    public function getControllerClass():string
+    public function getController():ControllerInterface
     {
-        return $this->controllerClass;
+        return $this->controller;
     }
 }


### PR DESCRIPTION
* Code improvement
* It is now possible to overcharge `RouterMiddleware` `executeController()` and `instantiateController()` methods in order to fine tune the controller instantiation and execution
* `ControllerInterface` does not require a constructor with only one argument anymore (however it is assumed that by default the first argument of the controller will the server request object (`ServerRequestInterface`))
* The method in charge of returning the PSR-7 response for a controller is renamed `getResponse()`